### PR TITLE
Fix incorrect input type annotation on backtick()

### DIFF
--- a/db_facts/util.py
+++ b/db_facts/util.py
@@ -1,6 +1,6 @@
-from typing import List
+from typing import List, Union
 import subprocess
 
 
-def backtick(cmd: List[str]) -> str:
+def backtick(cmd: Union[str, List[str]]) -> str:
     return subprocess.check_output(cmd).decode('utf-8').strip()

--- a/db_facts/util.py
+++ b/db_facts/util.py
@@ -1,5 +1,6 @@
+from typing import List
 import subprocess
 
 
-def backtick(cmd: str) -> str:
+def backtick(cmd: List[str]) -> str:
     return subprocess.check_output(cmd).decode('utf-8').strip()

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ import os
 import sys
 
 
-VERSION = '3.0.0'
+VERSION = '3.0.1'
 
 
 # From https://circleci.com/blog/continuously-deploying-python-packages-to-pypi-with-circleci/


### PR DESCRIPTION
Whoops!  Looks like `subprocess.check_output()` takes either a string or an a list - which means that so should our `backtick()` function.  Found while moving some internal code over to the new db-facts - that code is probably being a little too friendly with its imports into db-facts, granted :)

```sh
(db_facts-3.8.1) broz@graybookpro:~/src/db-facts$ python3
Python 3.8.1 (default, Jan 20 2020, 22:01:27) 
[Clang 11.0.0 (clang-1100.0.33.17)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import subprocess
>>> subprocess.check_output("ls")
b'CODE_OF_CONDUCT.md\nCONFIGURATION.md\nDEVELOPMENT.md\nDockerfile\nEXTENSIONS.md\nLICENSE\nMakefile\nREADME.md\nRakefile.quality\n__pycache__\nbin\ncover\ncoverage.xml\ndb_facts\ndb_facts.egg-info\ndeps.sh\nmetrics\nnosetests.xml\npublish.sh\nrequirements.txt\nsetup.cfg\nsetup.py\ntest-reports\ntests\ntypecover\n'
>>> subprocess.check_output(["ls"])
b'CODE_OF_CONDUCT.md\nCONFIGURATION.md\nDEVELOPMENT.md\nDockerfile\nEXTENSIONS.md\nLICENSE\nMakefile\nREADME.md\nRakefile.quality\n__pycache__\nbin\ncover\ncoverage.xml\ndb_facts\ndb_facts.egg-info\ndeps.sh\nmetrics\nnosetests.xml\npublish.sh\nrequirements.txt\nsetup.cfg\nsetup.py\ntest-reports\ntests\ntypecover\n'
>>> 
```