### PR TITLE
Update method call to yaml.safe_load

### DIFF
--- a/tests/test_runner_success_config.py
+++ b/tests/test_runner_success_config.py
@@ -47,5 +47,5 @@ class TestRunnerSuccessConfig(unittest.TestCase):
                 }
             }
         }
-        self.assertEqual(yaml.load(mock_stdout.getvalue()),
+        self.assertEqual(yaml.safe_load(mock_stdout.getvalue()),
                          parsed_yaml_value)


### PR DESCRIPTION
yaml.load is deprecated for security reasons