### PR TITLE
Update pyenv python version for macos compatibility

### DIFF
--- a/.python-version
+++ b/.python-version
@@ -1,1 +1,1 @@
-db_facts-3.8.3
+db_facts-3.8.4

--- a/deps.sh
+++ b/deps.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 
-python_version=3.8.3
+python_version=3.8.4
 # zipimport.ZipImportError: can't decompress data; zlib not available:
 #    You may need `xcode-select --install` on OS X
 #    https://github.com/pyenv/pyenv/issues/451#issuecomment-151336786


### PR DESCRIPTION
I can't find the documentation about this, but I believe certain versions of python regularly become incompatible with updated macos versions, and I believe that is what has happened with python 3.8.3, which I can't successfully install on my macos (intel chip). 

pyenv is successfully able to install 3.8.4, so that's the update I make here.