### PR TITLE
Sanitize exports - remove characters that are not letters, numbers, or _

### DIFF
--- a/db_facts/exports.py
+++ b/db_facts/exports.py
@@ -10,17 +10,21 @@ formatted_key = {
     'database': 'DB_DATABASE',
 }
 
+
 def char_valid(char):
     return char.isalnum() or char == '_'
 
+
 def only_valid_chars(string):
     return ''.join(filter(char_valid, string))
+
 
 def format_key(key):
     if key in formatted_key:
         return formatted_key[key]
 
     return only_valid_chars(key).upper()
+
 
 def print_exports(exports):
     for k, v in sorted(exports.items()):

--- a/db_facts/exports.py
+++ b/db_facts/exports.py
@@ -10,9 +10,20 @@ formatted_key = {
     'database': 'DB_DATABASE',
 }
 
+def char_valid(char):
+    return char.isalnum() or char == '_'
+
+def only_valid_chars(string):
+    return ''.join(filter(char_valid, string))
+
+def format_key(key):
+    if key in formatted_key:
+        return formatted_key[key]
+
+    return only_valid_chars(key).upper()
 
 def print_exports(exports):
     for k, v in sorted(exports.items()):
-        env_var = formatted_key.get(k, k.upper())
+        env_var = format_key(k)
         print("export " + env_var)
         print(env_var + "=" + pipes.quote(str(v)))

--- a/tests/test_runner_success.py
+++ b/tests/test_runner_success.py
@@ -22,6 +22,7 @@ class TestRunner(unittest.TestCase):
             'port': 123,
             'database': 'dbname',
             'lastpass_share_name_suffix': 'lastpass_share_name_suffix',
+            'not-valid*_characters1': 'whatever',
             'connection_type': 'connection_type',
         }
 
@@ -38,6 +39,8 @@ class TestRunner(unittest.TestCase):
                          'export LASTPASS_SHARE_NAME_SUFFIX\n'
                          'LASTPASS_SHARE_NAME_SUFFIX='
                          'lastpass_share_name_suffix\n'
+                         'export NOTVALID_CHARACTERS1\n'
+                         'NOTVALID_CHARACTERS1=whatever\n'
                          'export DB_PASSWORD\n'
                          'DB_PASSWORD=password\n'
                          'export DB_PORT\n'


### PR DESCRIPTION
This enables the common use case `eval $(db-facts sh redshift)` when a user has a special character such as a hyphen in their name.