### PR TITLE
Mods 29 alternate

### DIFF
--- a/db_facts/aws_secrets_manager.py
+++ b/db_facts/aws_secrets_manager.py
@@ -4,6 +4,23 @@ import boto3
 
 from .db_facts_types import AWSSecret, AWSSecretUsernamePassword
 from .db_type import canonicalize_db_type, db_protocol
+import re
+
+
+"""
+Takes a lastpass secret_id and translates it to the corresponding aws secret_id
+"""
+def translate_secret_id_to_sm(secret_id: str) -> str:
+    cms_secret_pattern = r'(CMS Vertica) (\([a-z]+\)): ([a-z]+)'
+    cms_secret_pattern = re.compile(cms_secret_pattern)
+    if cms_secret_pattern.match(secret_id):
+        match = re.search(cms_secret_pattern, secret_id)
+        stack = match.group(2).replace('(', '').replace(')', '')
+        username = match.group(3)
+        secretsmanager_secret_id = f'{stack}_vertica_{username}_creds'
+    else:
+        raise NotImplementedError("Currently only CMS secret IDs can be translated to secretsmanager")
+    return secretsmanager_secret_id
 
 
 def pull_aws_secrets_manager_secret(sm_entry_name: str) -> AWSSecret:

--- a/db_facts/db_info.py
+++ b/db_facts/db_info.py
@@ -4,11 +4,11 @@ from .template import template, template_any
 from .jinja_context import pull_jinja_context
 from .errors import fail_on_invalid_db_name
 from .config import load_config
-from .lpass import pull_lastpass_username_password, db_info_from_lpass, pull_lastpass_aws_iam, db_info_from_secretsmanager
-from .aws_secrets_manager import (
-    db_info_from_secrets_manager,
-    pull_aws_secrets_manager_username_password
-)
+from .lpass import pull_lastpass_username_password, db_info_from_lpass, db_info_from_secretsmanager
+# from .aws_secrets_manager import (
+#     db_info_from_secrets_manager,
+#     pull_aws_secrets_manager_username_password
+# )
 from .db_facts_types import DBConfig, DBCLIConfig, DBFacts, DBName
 from .db_config import db_config
 
@@ -87,33 +87,33 @@ def db(db_name: DBName, dbcli_config: DBCLIConfig = None, secret_type:str=None) 
             additional_attributes = \
                 pull_lastpass_username_password(lastpass_entry_name)
             db_info['exports'].update(additional_attributes)
-        elif 'pull_lastpass_aws_iam' in dbcli_config['exports_from'][method]:
-            method = dbcli_config['exports_from'][method]
-            template_for_lastpass_entry_name =\
-                method['pull_lastpass_aws_iam']
-            lastpass_entry_name = template(template_for_lastpass_entry_name,
-                                           (db_info, {}))
-            additional_attributes = \
-                pull_lastpass_aws_iam(lastpass_entry_name)
-            db_info['exports'].update(additional_attributes)
-        elif 'pull_secrets_manager_from' in dbcli_config['exports_from'][method]:
-            template_for_secrets_manager_entry_name =\
-                dbcli_config['exports_from'][method]['pull_secrets_manager_from']
-            secrets_manager_entry_name = template(template_for_secrets_manager_entry_name,
-                                                  (db_info, {}))
-            additional_attributes = \
-                db_info_from_secrets_manager(secrets_manager_entry_name)
-            db_info['exports'].update(additional_attributes)
-        elif 'pull_secrets_manager_username_password_from' in \
-             dbcli_config['exports_from'][method]:
-            method = dbcli_config['exports_from'][method]
-            template_for_secrets_manager_entry_name =\
-                method['pull_secrets_manager_username_password_from']
-            secrets_manager_entry_name = template(template_for_secrets_manager_entry_name,
-                                           (db_info, {}))
-            additional_attributes = \
-                pull_aws_secrets_manager_username_password(secrets_manager_entry_name)
-            db_info['exports'].update(additional_attributes)
+        # elif 'pull_lastpass_aws_iam' in dbcli_config['exports_from'][method]:
+        #     method = dbcli_config['exports_from'][method]
+        #     template_for_lastpass_entry_name =\
+        #         method['pull_lastpass_aws_iam']
+        #     lastpass_entry_name = template(template_for_lastpass_entry_name,
+        #                                    (db_info, {}))
+        #     additional_attributes = \
+        #         pull_lastpass_aws_iam(lastpass_entry_name)
+        #     db_info['exports'].update(additional_attributes)
+        # elif 'pull_secrets_manager_from' in dbcli_config['exports_from'][method]:
+        #     template_for_secrets_manager_entry_name =\
+        #         dbcli_config['exports_from'][method]['pull_secrets_manager_from']
+        #     secrets_manager_entry_name = template(template_for_secrets_manager_entry_name,
+        #                                           (db_info, {}))
+        #     additional_attributes = \
+        #         db_info_from_secrets_manager(secrets_manager_entry_name)
+        #     db_info['exports'].update(additional_attributes)
+        # elif 'pull_secrets_manager_username_password_from' in \
+        #      dbcli_config['exports_from'][method]:
+        #     method = dbcli_config['exports_from'][method]
+        #     template_for_secrets_manager_entry_name =\
+        #         method['pull_secrets_manager_username_password_from']
+        #     secrets_manager_entry_name = template(template_for_secrets_manager_entry_name,
+        #                                    (db_info, {}))
+        #     additional_attributes = \
+        #         pull_aws_secrets_manager_username_password(secrets_manager_entry_name)
+        #     db_info['exports'].update(additional_attributes)
         else:
             raise SyntaxError(f'Did not understand exports_from {method}')
 

--- a/db_facts/db_info.py
+++ b/db_facts/db_info.py
@@ -4,7 +4,7 @@ from .template import template, template_any
 from .jinja_context import pull_jinja_context
 from .errors import fail_on_invalid_db_name
 from .config import load_config
-from .lpass import pull_lastpass_username_password, db_info_from_lpass, pull_lastpass_aws_iam
+from .lpass import pull_lastpass_username_password, db_info_from_lpass, pull_lastpass_aws_iam, db_info_from_secretsmanager
 from .aws_secrets_manager import (
     db_info_from_secrets_manager,
     pull_aws_secrets_manager_username_password
@@ -13,7 +13,7 @@ from .db_facts_types import DBConfig, DBCLIConfig, DBFacts, DBName
 from .db_config import db_config
 
 
-def db(db_name: DBName, dbcli_config: DBCLIConfig = None) -> DBFacts:
+def db(db_name: DBName, dbcli_config: DBCLIConfig = None, secret_type:str=None) -> DBFacts:
     """Get connection info for specified database.
 
     :param db_name: Alias for the particular database endpoint and account to connect to.  ['a','b','c'] corresponds to 'a-b-c' on the db-facts command-line.
@@ -69,9 +69,14 @@ def db(db_name: DBName, dbcli_config: DBCLIConfig = None) -> DBFacts:
                 dbcli_config['exports_from'][method]['pull_lastpass_from']
             lastpass_entry_name = template(template_for_lastpass_entry_name,
                                            (db_info, {}))
-            additional_attributes = \
-                db_info_from_lpass(lastpass_entry_name)
-            db_info['exports'].update(additional_attributes)
+            if secret_type == '--lpass':
+                additional_attributes = \
+                    db_info_from_lpass(lastpass_entry_name)
+                db_info['exports'].update(additional_attributes)
+            elif secret_type == '--aws':
+                additional_attributes = \
+                    db_info_from_secretsmanager(lastpass_entry_name)
+                db_info['exports'].update(additional_attributes)
         elif 'pull_lastpass_username_password_from' in \
              dbcli_config['exports_from'][method]:
             method = dbcli_config['exports_from'][method]

--- a/db_facts/lpass.py
+++ b/db_facts/lpass.py
@@ -15,22 +15,6 @@ def pull_lastpass_username_password(lastpass_entry_name: str) -> LastPassUsernam
     }
 
 
-"""
-Takes a lastpass secret_id and translates it to the 
-"""
-def translate_secret_id_to_sm(secret_id: str) -> str:
-    cms_secret_pattern = r'(CMS Vertica) (\([a-z]+\)): ([a-z]+)'
-    cms_secret_pattern = re.compile(cms_secret_pattern)
-    if cms_secret_pattern.match(secret_id):
-        match = re.search(cms_secret_pattern, secret_id)
-        stack = match.group(2).replace('(', '').replace(')', '')
-        username = match.group(3)
-        secretsmanager_secret_id = f'{stack}_vertica_{username}_creds'
-    else:
-        raise NotImplementedError("Currently only CMS secret IDs can be translated to secretsmanager")
-    return secretsmanager_secret_id
-
-
 def lpass_field(name: str, field: str) -> str:
     if field == 'notes':
         field_arg = '--notes'
@@ -49,17 +33,6 @@ def lpass_field(name: str, field: str) -> str:
     return raw_output.decode('utf-8').rstrip('\n')
 
 
-def sm_field(name: str, field: str) -> str:
-    sm_name = translate_secret_id_to_sm(name)
-    show_command = ["aws", "secretsmanager", "get-secret-value", "--secret-id", sm_name, "--output", "json"]
-    raw_output = check_output(show_command)
-    decoded_output = raw_output.decode('utf-8').rstrip('\n')
-    json_output = json.loads(decoded_output)
-    secret_string_json = json.loads(json_output['SecretString'])
-    sm_field = secret_string_json[field]
-    return sm_field
-
-
 def db_info_from_lpass(lpass_entry_name: str):
     user = lpass_field(lpass_entry_name, 'username')
     password = lpass_field(lpass_entry_name, 'password')
@@ -68,24 +41,6 @@ def db_info_from_lpass(lpass_entry_name: str):
     raw_db_type = lpass_field(lpass_entry_name, 'Type')
     db_type = canonicalize_db_type(raw_db_type)
     dbname = lpass_field(lpass_entry_name, 'Database')
-
-    return {'password': password,
-            'host': host,
-            'user': user,
-            'type': db_type,
-            'protocol': db_protocol(db_type),
-            'port': port,
-            'database': dbname}
-
-
-def db_info_from_secretsmanager(sm_entry_name: str):
-    user = sm_field(sm_entry_name, 'Username')
-    password = sm_field(sm_entry_name, 'Password')
-    host = sm_field(sm_entry_name, 'Hostname')
-    port = int(sm_field(sm_entry_name, 'Port'))
-    raw_db_type = sm_field(sm_entry_name, 'Type')
-    db_type = canonicalize_db_type(raw_db_type)
-    dbname = sm_field(sm_entry_name, 'Database')
 
     return {'password': password,
             'host': host,

--- a/db_facts/lpass.py
+++ b/db_facts/lpass.py
@@ -1,6 +1,11 @@
+import sys
 from subprocess import check_output
-from .db_facts_types import LastPassUsernamePassword, LastPassAWSIAM
+from .db_facts_types import LastPassUsernamePassword
 from .db_type import canonicalize_db_type, db_protocol
+import re
+import logging
+import json
+
 
 
 def pull_lastpass_username_password(lastpass_entry_name: str) -> LastPassUsernamePassword:
@@ -10,12 +15,20 @@ def pull_lastpass_username_password(lastpass_entry_name: str) -> LastPassUsernam
     }
 
 
-def pull_lastpass_aws_iam(lastpass_entry_name: str) -> LastPassAWSIAM:
-    result = pull_lastpass_username_password(lastpass_entry_name)
-    return {
-        'aws_access_key_id': result['user'],
-        'aws_secret_access_key': result['password']
-    }
+"""
+Takes a lastpass secret_id and translates it to the 
+"""
+def translate_secret_id_to_sm(secret_id: str) -> str:
+    cms_secret_pattern = r'(CMS Vertica) (\([a-z]+\)): ([a-z]+)'
+    cms_secret_pattern = re.compile(cms_secret_pattern)
+    if cms_secret_pattern.match(secret_id):
+        match = re.search(cms_secret_pattern, secret_id)
+        stack = match.group(2).replace('(', '').replace(')', '')
+        username = match.group(3)
+        secretsmanager_secret_id = f'{stack}_vertica_{username}_creds'
+    else:
+        raise NotImplementedError("Currently only CMS secret IDs can be translated to secretsmanager")
+    return secretsmanager_secret_id
 
 
 def lpass_field(name: str, field: str) -> str:
@@ -36,6 +49,17 @@ def lpass_field(name: str, field: str) -> str:
     return raw_output.decode('utf-8').rstrip('\n')
 
 
+def sm_field(name: str, field: str) -> str:
+    sm_name = translate_secret_id_to_sm(name)
+    show_command = ["aws", "secretsmanager", "get-secret-value", "--secret-id", sm_name, "--output", "json"]
+    raw_output = check_output(show_command)
+    decoded_output = raw_output.decode('utf-8').rstrip('\n')
+    json_output = json.loads(decoded_output)
+    secret_string_json = json.loads(json_output['SecretString'])
+    sm_field = secret_string_json[field]
+    return sm_field
+
+
 def db_info_from_lpass(lpass_entry_name: str):
     user = lpass_field(lpass_entry_name, 'username')
     password = lpass_field(lpass_entry_name, 'password')
@@ -44,6 +68,24 @@ def db_info_from_lpass(lpass_entry_name: str):
     raw_db_type = lpass_field(lpass_entry_name, 'Type')
     db_type = canonicalize_db_type(raw_db_type)
     dbname = lpass_field(lpass_entry_name, 'Database')
+
+    return {'password': password,
+            'host': host,
+            'user': user,
+            'type': db_type,
+            'protocol': db_protocol(db_type),
+            'port': port,
+            'database': dbname}
+
+
+def db_info_from_secretsmanager(sm_entry_name: str):
+    user = sm_field(sm_entry_name, 'Username')
+    password = sm_field(sm_entry_name, 'Password')
+    host = sm_field(sm_entry_name, 'Hostname')
+    port = int(sm_field(sm_entry_name, 'Port'))
+    raw_db_type = sm_field(sm_entry_name, 'Type')
+    db_type = canonicalize_db_type(raw_db_type)
+    dbname = sm_field(sm_entry_name, 'Database')
 
     return {'password': password,
             'host': host,

--- a/db_facts/runner.py
+++ b/db_facts/runner.py
@@ -30,10 +30,10 @@ class Runner():
         print(config_yaml(db_name_str, db_info), end='')
 
     def dump_sh(self, args: argparse.Namespace):
+        secret_type = '--lpass' if args.lpass else '--aws'
         db_name_str: str = args.dbname[0]
         db_name = db_name_str.split('-')
-
-        db_info = db(db_name)
+        db_info = db(db_name=db_name, secret_type=secret_type)
         print_exports(db_info)
 
     def run(self, argv: List[str]) -> int:
@@ -67,6 +67,13 @@ class Runner():
                                    help=('Friendly name of database '
                                          '(e.g., "redshift", "dmv", '
                                          '"abc-dev-dbadmin")'))
+            group = sh_parser.add_mutually_exclusive_group()
+            group.add_argument('--lpass', action='store_true',
+                               help=('type of secret service to pull from '
+                                         '(e.g., "--lpass"'))
+            group.add_argument('--aws', action='store_true',
+                               help=('type of secret service to pull from '
+                                         '(e.g., "--aws"'))
             sh_parser.set_defaults(func=self.dump_sh)
 
             args = parser.parse_args(argv[1:])

--- a/db_facts/runner.py
+++ b/db_facts/runner.py
@@ -30,7 +30,7 @@ class Runner():
         print(config_yaml(db_name_str, db_info), end='')
 
     def dump_sh(self, args: argparse.Namespace):
-        secret_type = '--lpass' if args.lpass else '--aws'
+        secret_type = '--aws' if args.aws else '--lpass'
         db_name_str: str = args.dbname[0]
         db_name = db_name_str.split('-')
         db_info = db(db_name=db_name, secret_type=secret_type)


### PR DESCRIPTION
**This work is still in progress** 

The goal of this commit is to extract AWS secret data instead of lpass when running `db-facts sh`.
The new command should look something like `db-facts sh "cms" --aws`.

Initially I created a method in `lpass.py` to parse the AWS response but I then realized that there is already a python script for this in the `aws_secrets_manager.py`. 

Essentially now the code in `db-info.py` checks if the flag is --aws or --lpass. 
If it's --aws then it converts the lpass secret id into aws secret id. The `db_info_from_secrets_manager` method is then called which returns the DB info from AWS.

Comments/Concerns:
- I commented out some of the Jinja code because I was getting errors when testing (will uncomment in the future).